### PR TITLE
feat: create reusable data card component

### DIFF
--- a/src/components/common/DataCard/DataCard.test.tsx
+++ b/src/components/common/DataCard/DataCard.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import DataCard, { ContentProperties, HeadingProperties } from "./DataCard";
+
+const mockHeading: HeadingProperties = {
+  title: "Test Title",
+  icon: <svg data-testid="test-icon" />,
+};
+
+const mockContent: ContentProperties = {
+  amount: "$100",
+  subtext: "Test Subtext",
+};
+
+describe("dataCard component", () => {
+  it("renders correctly with all required elements", () => {
+    expect.assertions(4);
+    render(<DataCard heading={mockHeading} content={mockContent} />);
+
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+
+    expect(screen.getByTestId("test-icon")).toBeInTheDocument();
+
+    expect(screen.getByText("$100")).toBeInTheDocument();
+
+    expect(screen.getByText("Test Subtext")).toBeInTheDocument();
+  });
+
+  it("is responsive", () => {
+    expect.assertions(4);
+
+    render(<DataCard heading={mockHeading} content={mockContent} />);
+
+    // Simulate viewport size changes and rerender the component
+    global.innerWidth = 600;
+    global.dispatchEvent(new Event("resize"));
+
+    expect(screen.getAllByText("Test Title")).toHaveLength(1);
+    expect(screen.getAllByText("$100")).toHaveLength(1);
+
+    global.innerWidth = 1200;
+    global.dispatchEvent(new Event("resize"));
+
+    expect(screen.getAllByText("Test Title")).toHaveLength(1);
+    expect(screen.getAllByText("$100")).toHaveLength(1);
+  });
+});

--- a/src/components/common/DataCard/DataCard.tsx
+++ b/src/components/common/DataCard/DataCard.tsx
@@ -1,0 +1,53 @@
+import { cn } from "../../../lib/utils";
+import { Card, CardContent, CardHeader, CardTitle } from "../../ui/card";
+
+export type HeadingProperties = {
+  title: string;
+  icon: React.ReactNode;
+};
+
+export type ContentProperties = {
+  amount: string;
+  subtext: string;
+};
+
+export type DataCardProperties = {
+  heading: HeadingProperties;
+  content: ContentProperties;
+};
+
+const DataCard = ({ heading, content }: DataCardProperties) => {
+  return (
+    <>
+      <Card
+        className={cn(
+          "bg-card border-[0.5px] border-border flex flex-col w-[325px] text-[#0A0A0A] gap-1 px-6 pt-[1.4rem] pb-10 shadow-[0px_1px_18px_0px_#0A39B01F] rounded-[0.75rem]",
+        )}
+        aria-labelledby="card-title"
+      >
+        <CardHeader className="flex flex-row items-center justify-between w-full space-y-0 p-0">
+          <CardTitle className="text-sm leading-[1rem] text-balance">
+            {heading.title}
+          </CardTitle>
+          <div className="w-6 h-6" aria-label="Card Icon">
+            {heading.icon}
+          </div>
+        </CardHeader>
+
+        <CardContent
+          className="flex flex-col items-start w-full p-0"
+          aria-describedby="card-content-description"
+        >
+          <p className="text-2xl leading-7 font-semibold text-balance">
+            {content.amount}
+          </p>
+          <p className="font-normal text-xs leading-[0.9rem] text-balance">
+            {content.subtext}
+          </p>
+        </CardContent>
+      </Card>
+    </>
+  );
+};
+
+export default DataCard;

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};


### PR DESCRIPTION
<!-- Do not delete this PR template. Just edit it to include the required information -->

# Description

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->
Adds a reusable DataCard component. The DataCard displays a heading with a title and an icon and a content section that includes an amount and subtext.
<!-- Github Issue Example: Closes #31 -->

**Closes #180**

# Changes proposed

## What were you told to do?

<!-- Write the title of the issue/feature you are working on -->
**[FEAT] - Component → DataCard**

Create a reusable DataCard component using Shadcn and Next.js. The DataCard component should display a heading with a title and an icon and a content section that includes an amount and subtext.

### Requirements

- The data card component is implemented according to the design.

- The component should be fully responsive and look good on all screen sizes.

- Ensure accessibility standards are met, including appropriate aria attributes and proper semantic HTML.

## What did you do?

<!-- Talk about the things you did eg. files changes, dependencies installed e.t.c -->

Created a reusable `DataCard` component. This component is based on the Card component from Shadcn-ui. 

The `DataCard` component displays a card with a heading and content section. It is fully responsive and designed to meet accessibility standards. It receives the following props:

### Props:
 
`heading`

**Type**: `object`
**Required**: `true`
**Description**: Contains the title and icon for the card.
- **Properties**:
     - `title` (string): The title displayed in the card heading.
     - `icon` (React.ReactNode): A React node representing the icon.

`content`

**Type**: `object`
**Required**: `true`
**Description**: Contains the amount and subtext to display in the card content.
- **Properties**:
     - `amount` (string): The main amount with the currency sign prepended to display in the content section.
     - `subtext` (string): Additional text to provide context for the amount.

### Usage
```typescript
import DataCard, { ContentProperties, HeadingProperties } from "~/components/common/DataCard/DataCard";

const Example = () => {
  const heading: HeadingProperties = {
    title: 'Revenue',
    icon: <svg>...</svg>, // Replace with your icon
  };

  const content: ContentProperties = {
    amount: '$5000',
    subtext: 'Total Revenue for Q1',
  };

  return <DataCard heading={headingProps} content={contentProps} />;
};

```

# Check List (Check all the applicable boxes)

🚨Please review the [contribution guideline](CONTRIBUTING.md) for this repository.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the **dev branch** (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshots/Videos
![DataCard Component](https://github.com/user-attachments/assets/012b7aae-db84-493c-9f47-a85b060a4d28)


<!-- If the changes are static page changes or UI changes add screenshots -->
<!-- If the changes involve implementing a functionality or working with apis, include a video
detailing how to implement the functionality and the request to the api and responses from the api endpoint-->
<!-- Add all the screenshots/videos which support your changes i.e before your change and after your change -->
