### PR TITLE
feat/HNG-8-create-reusable-tooltip

### DIFF
--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -11,20 +11,90 @@ const Tooltip = TooltipPrimitive.Root;
 
 const TooltipTrigger = TooltipPrimitive.Trigger;
 
+type ColorVariant = "primary" | "secondary" | "neutral";
+
+type ColorValue = { bgColor: string; textColor: string; arrowColor: string };
+// { primary: ColorVal; secondary: ColorVal; neutral: ColorVal }
+const colorStyles: Record<ColorVariant, ColorValue> = {
+  primary: {
+    bgColor: "bg-[#F97316]",
+    textColor: "text-white",
+    arrowColor: "fill-[#F97316]",
+  },
+  secondary: {
+    bgColor: "bg-white",
+    textColor: "text-[#F97316]",
+    arrowColor: "fill-white",
+  },
+  neutral: {
+    bgColor: "bg-white",
+    textColor: "text-[#0A0A0A]",
+    arrowColor: "fill-white",
+  },
+};
+
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...properties }, reference) => (
-  <TooltipPrimitive.Content
-    ref={reference}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> & {
+    arrowPosition?: "top" | "bottom" | "left" | "right";
+    header?: string;
+    body?: string;
+    subText?: string;
+    colorVariant?: "primary" | "secondary" | "neutral";
+  }
+>(
+  (
+    {
       className,
-    )}
-    {...properties}
-  />
-));
+      arrowPosition = "top",
+      sideOffset = 4,
+      header,
+      body,
+      subText,
+      colorVariant = "primary",
+      ...properties
+    },
+    reference,
+  ) => {
+    const colorVariantKey: ColorVariant = colorVariant;
+
+    const { bgColor, textColor, arrowColor } = colorStyles[colorVariantKey];
+
+    return (
+      <TooltipPrimitive.Content
+        ref={reference}
+        side={arrowPosition}
+        sideOffset={sideOffset}
+        className={cn(
+          `z-50 flex h-[41px] w-[189px] flex-col gap-[12px] overflow-hidden rounded-md p-[12px] px-3 py-1.5 text-xs animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 lg:h-[94px] lg:w-[384px] lg:!pb-[16px] xl:h-[132px] xl:w-[384px]`,
+          bgColor,
+          textColor,
+          className,
+        )}
+        style={{ boxShadow: "0px 3px 14px 3px #0A39B01F" }}
+        {...properties}
+      >
+        {header && (
+          <div className="hidden text-[14px] font-semibold leading-[16.94px] lg:block">
+            {header}
+          </div>
+        )}
+        {body && (
+          <div className="lg:clamp-2 mb-1 overflow-hidden truncate text-[14px] font-medium leading-[16.94px] lg:whitespace-normal">
+            {body}
+          </div>
+        )}
+        {subText && (
+          <div className="xl:clamp-2 hidden overflow-hidden whitespace-normal text-[12px] font-[400] leading-[14.52px] xl:block">
+            {subText}
+          </div>
+        )}
+        <TooltipPrimitive.Arrow className={arrowColor} />
+      </TooltipPrimitive.Content>
+    );
+  },
+);
+
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };


### PR DESCRIPTION
<!-- Do not delete this PR template. Just edit it to include the required information -->

# Description
Tooltip reusable component
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Github Issue Example: Closes #31 -->
#8 
**Closes #issue_number_here**

# Changes proposed

## What were you told to do?
Creating a dynamic reusable component
<!-- Write the title of the issue/feature you are working on -->
feat/HNG-8-create-reusable-tooltip
## What did you do?
-I fork the repo and clone it
-I run pnpm install
-I made the tootip component dynamic
-I run pnpm lint and then pnpm lint:fix
<!-- Talk about the things you did eg. files changes, dependencies installed e.t.c -->

# Check List (Check all the applicable boxes)

🚨Please review the [contribution guideline](CONTRIBUTING.md) for this repository.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title and description of the PR is clear and explains the approach.
- [X] I am making a pull request against the **dev branch** (left side).
- [X] My commit messages styles matches our requested structure.
- [X] My code additions will fail neither code linting checks nor unit test.
- [X] I am only making changes to files I was requested to.

# Screenshots/Videos

<!-- If the changes are static page changes or UI changes add screenshots -->
<!-- If the changes involve implementing a functionality or working with apis, include a video
detailing how to implement the functionality and the request to the api and responses from the api endpoint-->
<!-- Add all the screenshots/videos which support your changes i.e before your change and after your change -->

![Before hovering](https://github.com/user-attachments/assets/11abf8c7-94c9-4e98-bbfc-0e7cbe2297de)


![Hovering on extra  large devices](https://github.com/user-attachments/assets/806aa03f-3d05-43d7-bc65-0e176b825b25)
![extra large devices with with with colorVariant set to secondary](https://github.com/user-attachments/assets/99da708f-2dfe-4e83-b755-ac71f303cf49)
![Extra large dvices with colorVariant set to neutral](https://github.com/user-attachments/assets/7f516017-2a63-4c99-b26e-e073f383bc10)

![Large devices](https://github.com/user-attachments/assets/78b22671-a22f-41af-9dec-c3d53da7bd8e)
![Large devices](https://github.com/user-attachments/assets/b25f38fd-3f53-4525-83cf-417c176d1d34)
![Large devices](https://github.com/user-attachments/assets/feb4629d-f161-4fd3-a5e9-d5b70a2d2b1b)

![Small devices](https://github.com/user-attachments/assets/6f340644-85c1-4c86-bcee-4d943a7f576a)
![Small devices](https://github.com/user-attachments/assets/8763d65f-b881-40dd-964f-dc5dae49a9dc)
![Small devices](https://github.com/user-attachments/assets/4efd45b1-a5f6-4a7e-b71b-028a15941365)
