### PR TITLE
fix: Updated the component's background color to #000 to match latest…

### DIFF
--- a/src/components/external_static_page/SubPageHero.tsx
+++ b/src/components/external_static_page/SubPageHero.tsx
@@ -8,7 +8,7 @@ const SubPageHero = ({
   description = "Get Your Free Boilerplate Samples!",
 }: SubPageHeroProperty) => {
   return (
-    <div className="relative box-border flex h-[13.438rem] w-full shrink-0 flex-col items-center justify-center overflow-hidden bg-black bg-opacity-70 px-[0rem] py-[4.687rem] text-center text-[2rem] text-white md:h-[20.25rem] md:text-[3.75rem]">
+    <div className="relative box-border flex h-[13.438rem] w-full shrink-0 flex-col items-center justify-center overflow-hidden bg-black px-[0rem] py-[4.687rem] text-center text-[2rem] text-white md:h-[20.25rem] md:text-[3.75rem]">
       <div className="flex flex-col items-center justify-start gap-[0.25rem] self-stretch">
         <b className="relative self-stretch">{heading}</b>
         <div className="relative self-stretch text-[1.25rem] md:text-[1.75rem]">


### PR DESCRIPTION
This PR Ipdates the color changes made to the design from `#00000007` to `#000` thereby removing the `70%` opacity.

#56 

- All test passes successfully
- There's no conflict with dev branch
- There is no lint errors and the implementation is pixel perfect

![Screenshot from 2024-07-21 00-37-10](https://github.com/user-attachments/assets/f0fe56bb-3bc5-45e8-b19b-f67128b6185c)


![Screenshot from 2024-07-21 00-36-17](https://github.com/user-attachments/assets/359c2427-4254-4347-ba09-366ac8f893eb)

![Screenshot from 2024-07-21 00-38-39](https://github.com/user-attachments/assets/49464ace-22f7-440b-a863-83149ab6ea15)

![Screenshot from 2024-07-21 00-38-19](https://github.com/user-attachments/assets/f50e32af-28f9-40ff-a1b1-f81db81aa60d)


![Screenshot from 2024-07-21 00-50-12](https://github.com/user-attachments/assets/421ea688-5ea7-4b44-be90-e3e80461d6a1)

![Screenshot from 2024-07-21 00-50-25](https://github.com/user-attachments/assets/0b6acd19-d564-4d67-b5b5-364c777e4e13)
