### PR TITLE
Bugs/hng 888 bugs in auth

### DIFF
--- a/src/app/(auth-routes)/login/page.tsx
+++ b/src/app/(auth-routes)/login/page.tsx
@@ -69,7 +69,7 @@ const Login = () => {
       await loginAuth(values).then(async (data) => {
         const { email, password } = values;
 
-        if (data) {
+        if (!data.error) {
           await signIn(
             "credentials",
             {
@@ -81,6 +81,7 @@ const Login = () => {
           );
           router.push("/dashboard");
         }
+
         toast({
           title: data.status === 200 ? "Login success" : "An error occurred",
           description: data.status === 200 ? "Redirecting" : data.error,

--- a/src/app/(auth-routes)/register/page.tsx
+++ b/src/app/(auth-routes)/register/page.tsx
@@ -67,7 +67,7 @@ const Register = () => {
   const onSubmit = async (values: z.infer<typeof RegisterSchema>) => {
     startTransition(async () => {
       await registerAuth(values).then(async (data) => {
-        if (data) {
+        if (!data.error) {
           sessionStorage.setItem("temp_token", data.access_token);
           router.push("/register/organisation");
         }
@@ -79,7 +79,6 @@ const Register = () => {
               : "an error occurred",
           description: data.status === 201 ? "Redirecting" : data.error,
         });
-        router.push("/register/organisation");
       });
     });
   };


### PR DESCRIPTION
close #888 

# Description:

This PR addresses the issue where users are incorrectly navigated to the dashboard or create organization page when the server is down during login or registration attempts. Instead of navigating, a toast notification with the appropriate error message will be displayed, and the user will remain on the same page


# Changes Implemented:

- Added a check to prevent navigation to the dashboard if the response from the  api includes error.
- Added a check to prevent navigation to the create organisation page if the response from the  api includes error.


# Expected Behavior:
### When the server is down:
 - The user should remain on the login or registration page.
 - A toast should pop up notifying the user with the appropriate error message.

[Screencast from 2024-08-02 17-29-32.webm](https://github.com/user-attachments/assets/cbf6d0a9-0bc4-43b3-baf5-0e32884870d6)
