### PR TITLE
Fix: Issue where go to plans text was not routing to the plans page

### DIFF
--- a/src/app/dashboard/(admin)/admin/(settings)/settings/organization/members/page.tsx
+++ b/src/app/dashboard/(admin)/admin/(settings)/settings/organization/members/page.tsx
@@ -2,6 +2,7 @@
 
 import { AxiosResponse } from "axios";
 import { EllipsisIcon } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 
 import CustomButton from "~/components/common/common-button/common-button";
@@ -184,7 +185,13 @@ const Members = () => {
         <p className="text-sm">
           On the Free plan all members in a workspace are administrators.
           Upgrade to a paid plan to add the ability to assign or remove
-          administrator roles. <span className="text-primary">Go to Plans</span>
+          administrator roles.{" "}
+          <Link
+            href={"/dashboard/admin/settings/organization/payment-information"}
+            className="text-primary"
+          >
+            Go to Plans
+          </Link>
         </p>
       </div>
       <div className="my-8 flex justify-between">


### PR DESCRIPTION
<!-- Do not delete this PR template. Just edit it to include the required information -->

# Description

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Github Issue Example: Closes #31 -->

**Closes #1136**

# Changes proposed

## What were you told to do?
The "Go to plans" hypertext on the Members page should be clickable and direct users to a page where they can view, select, and upgrade to available pricing plans.
<!-- Write the title of the issue/feature you are working on -->

## What did you do?
Users are able to click the "Go to plans" hypertext and are directed to the correct page.
<!-- Talk about the things you did eg. files changes, dependencies installed e.t.c -->

# Check List (Check all the applicable boxes)

🚨Please review the [contribution guideline](CONTRIBUTING.md) for this repository.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Correct; marked as **not** done

[] - Not Correct; syntax error
[ x] - Not Correct; space between the brackets
-->

- [ ] My code follows the code style of this project.
- [ ] This PR does not contain plagiarized content.
- [ ] The title and description of the PR is clear and explains the approach.
- [ ] I am making a pull request against the **dev branch** (left side).
- [ ] My commit messages styles matches our requested structure.
- [ ] My code additions will fail neither code linting checks nor unit test.
- [ ] I am only making changes to files I was requested to.

# Screenshots/Videos

<!-- If the changes are static page changes or UI changes add screenshots -->
<!-- If the changes involve implementing a functionality or working with apis, include a video
detailing how to implement the functionality and the request to the api and responses from the api endpoint-->
<!-- Add all the screenshots/videos which support your changes i.e before your change and after your change -->
